### PR TITLE
Adding documentation template to function extractBrainConvHull

### DIFF
--- a/src/Functions/extractBrainConvHull.m
+++ b/src/Functions/extractBrainConvHull.m
@@ -6,11 +6,11 @@ function [convHullBrainMask, roughBrainMask] = extractBrainConvHull(niiCT)
 %    [convHullBrainMask, roughBrainMask] = extractBrainConvHull(niiCT)
 %
 % INPUT: 
-%    niiCT:     
+%    niiCT:     NiftiMod object of a post-operative CT image
 %
 % OUTPUTS: 
-%   convHullBrainMask:      
-%   roughBrainMask:         
+%   convHullBrainMask:      Estimated mask of the convex hull of the brain
+%   roughBrainMask:         Estimated rough brain mask wich may contain inaccuracies
 %
 % .. AUTHOR:
 %       - Andreas Husch, Original File

--- a/src/Functions/extractBrainConvHull.m
+++ b/src/Functions/extractBrainConvHull.m
@@ -1,13 +1,22 @@
-%% Extracts the convex hull of the brain out of a CT image
-%
-% Andreas Husch
-% Centre Hospitalier de Luxembourg, Dept. of Neurosurgery /
-% University of Luxembourg - Luxembourg Centre for Systems Biomedicne
-% 2015 - 2017
-% mail@andreashusch.de, husch.andreas@chl.lu
 function [convHullBrainMask, roughBrainMask] = extractBrainConvHull(niiCT)
-%% force caching
-niiCT.isToBeCached = 1;
+% Extracts the convex hull of the brain out of a CT image
+%
+% USAGE:
+%
+%    [convHullBrainMask, roughBrainMask] = extractBrainConvHull(niiCT)
+%
+% INPUT: 
+%    niiCT:     
+%
+% OUTPUTS: 
+%   convHullBrainMask:      
+%   roughBrainMask:         
+%
+% .. AUTHOR:
+%       - Andreas Husch, Original File
+%       - Daniel Duarte Tojal, Documentation
+
+niiCT.isToBeCached = 1; % force caching
 if(~niiCT.isLoaded)
     niiCT.load();
 end


### PR DESCRIPTION
Descriptions of the Input `niiCT` and the Outputs `convHullBrainMask` and `roughBrainMask` to be determined.