### PR TITLE
change of name of function orr to oor

### DIFF
--- a/src/Functions/oor.m
+++ b/src/Functions/oor.m
@@ -11,7 +11,7 @@
 % mail@andreashusch.de
 %
 % That code needs some cleanup :-) But it works ;-)
-function [improvedSkeleton, medIntensity,orthIntensVol, orthSamplePointsVol, skelScaleMm] = orr(r3polyToUse, STEP_SIZE, XGrid, YGrid, interpolationF)
+function [improvedSkeleton, medIntensity,orthIntensVol, orthSamplePointsVol, skelScaleMm] = oor(r3polyToUse, STEP_SIZE, XGrid, YGrid, interpolationF)
 SND_THRESH=1500;
 
 arcLength = polyArcLength3(r3polyToUse, 0, 1);


### PR DESCRIPTION
this is the only occurrence of `orr` in the files, while the main function is supposed to be called `oor`.