### PR TITLE
PACER Testsuite

### DIFF
--- a/test/base/runScriptFile.m
+++ b/test/base/runScriptFile.m
@@ -1,7 +1,7 @@
 function result = runScriptFile(fileName)
 % This function runs the test in fileName
 % It can distinguish between skipped and Failed tests. A test is considered
-% to be skipped if it throws a COBRA:RequirementsNotMet error.
+% to be skipped if it throws a PACER:RequirementsNotMet error.
 %
 % OUTPUTS:
 %
@@ -25,20 +25,20 @@ function result = runScriptFile(fileName)
 
 global CBT_MISSING_REQUIREMENTS_ERROR_ID
 
-COBRA_TESTSUITE_TESTFILE = fileName;
+PACER_TESTSUITE_TESTFILE = fileName;
 
 % get the timinig (and hope these values are not overwritten.
-COBRA_TESTSUITE_STARTTIME = clock();
+PACER_TESTSUITE_STARTTIME = clock();
 
 try
     % run the file
     executefile(fileName);
 catch ME
     % vatch errors and interpret them
-    clearvars -except ME COBRA_TESTSUITE_STARTTIME COBRA_TESTSUITE_TESTFILE CBT_MISSING_REQUIREMENTS_ERROR_ID
-    scriptTime = etime(clock(), COBRA_TESTSUITE_STARTTIME);
+    clearvars -except ME PACER_TESTSUITE_STARTTIME PACER_TESTSUITE_TESTFILE CBT_MISSING_REQUIREMENTS_ERROR_ID
+    scriptTime = etime(clock(), PACER_TESTSUITE_STARTTIME);
     result = struct('status', 'failed', 'failed', true, 'passed', false, 'skipped', false, 'fileName', ...
-                    COBRA_TESTSUITE_TESTFILE, 'time', scriptTime, 'statusMessage', 'fail', 'Error', ME);
+                    PACER_TESTSUITE_TESTFILE, 'time', scriptTime, 'statusMessage', 'fail', 'Error', ME);
     if strcmp(ME.identifier, CBT_MISSING_REQUIREMENTS_ERROR_ID)
         % requirement missing, so the test was skipped.
         result.status = 'skipped';
@@ -55,10 +55,10 @@ catch ME
 end
 
 % get the timinig.
-scriptTime = etime(clock(), COBRA_TESTSUITE_STARTTIME);
+scriptTime = etime(clock(), PACER_TESTSUITE_STARTTIME);
 
 result = struct('status', 'passed', 'failed', false, 'passed', true, 'skipped', false, 'fileName', ...
-                COBRA_TESTSUITE_TESTFILE, 'time', scriptTime, 'statusMessage', 'success', 'Error', MException('', ''));
+                PACER_TESTSUITE_TESTFILE, 'time', scriptTime, 'statusMessage', 'success', 'Error', MException('', ''));
 
 end
 


### PR DESCRIPTION
The name of the following variables located in PaCER/test/base/runScriptFile.m have been adapted to PACER:

- COBRA _TESTSUITE_STARTTIME has been changed to PACER_TESTSUITE_STARTTIME 

- COBRA_TESTSUITE_TESTFILE has been changed to PACER_TESTSUITE_TESTFILE